### PR TITLE
fix: allow connect-timeout-ms request header in CORS

### DIFF
--- a/envoy.yaml
+++ b/envoy.yaml
@@ -42,7 +42,7 @@ static_resources:
                           allow_origin_string_match:
                             - prefix: "*"
                           allow_methods: GET, PUT, DELETE, POST, OPTIONS
-                          allow_headers: keep-alive,user-agent,cache-control,content-type,content-transfer-encoding,x-accept-content-transfer-encoding,x-accept-response-streaming,x-user-agent,x-grpc-web,grpc-timeout,grpc-message-type,connect-protocol-version,connect-timeout-ms,content-encoding,accept-encoding,connect-content-encoding,connect-accept-encoding
+                          allow_headers: keep-alive,user-agent,cache-control,content-type,content-transfer-encoding,x-accept-content-transfer-encoding,x-accept-response-streaming,x-user-agent,x-grpc-web,grpc-timeout,connect-protocol-version,connect-timeout-ms
                           max_age: "1728000"
                           expose_headers: grpc-status,grpc-message,grpc-status-details-bin
                 http_filters:

--- a/envoy.yaml
+++ b/envoy.yaml
@@ -42,9 +42,9 @@ static_resources:
                           allow_origin_string_match:
                             - prefix: "*"
                           allow_methods: GET, PUT, DELETE, POST, OPTIONS
-                          allow_headers: keep-alive,user-agent,cache-control,content-type,content-transfer-encoding,x-accept-content-transfer-encoding,x-accept-response-streaming,x-user-agent,x-grpc-web,grpc-timeout,connect-protocol-version
+                          allow_headers: keep-alive,user-agent,cache-control,content-type,content-transfer-encoding,x-accept-content-transfer-encoding,x-accept-response-streaming,x-user-agent,x-grpc-web,grpc-timeout,grpc-message-type,connect-protocol-version,connect-timeout-ms,content-encoding,accept-encoding,connect-content-encoding,connect-accept-encoding
                           max_age: "1728000"
-                          expose_headers: grpc-status,grpc-message
+                          expose_headers: grpc-status,grpc-message,grpc-status-details-bin
                 http_filters:
                   - name: envoy.filters.http.cors
                     typed_config:


### PR DESCRIPTION
This allows browser clients to send the `connect-timeout-ms` header across domains.

It also exposes the response header `grpc-status-details-bin` to make error details with the gRPC-web protocol available to browser clients.